### PR TITLE
feat: Add package workflow

### DIFF
--- a/.github/workflows/release-package.yml
+++ b/.github/workflows/release-package.yml
@@ -1,0 +1,30 @@
+name: S12 Amplify
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - run: npm ci
+      - run: npm test
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@s12solutions:registry=https://npm.pkg.github.com


### PR DESCRIPTION
*Issue #, if available:*
Not recorded, but Github changes to https auth as at 30th June 2021 appear to block this repo from being imported into an another repo.

*Description of changes:*
Publish this fork as a GH package and import accordingly into external apps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.